### PR TITLE
Remove rogue value breaking syntax in light-mode variables

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -274,7 +274,7 @@ body {
   --callout-question: 207, 186, 0;
 
   /* 2.k —— Syntax Highlighting                */
-  --code-comment:     #82A2C8;416a82
+  --code-comment:     #82A2C8;
   --code-tag:         #E83A78;
   --code-punctuation: #527EB2;
   --code-value:       #4696F4;


### PR DESCRIPTION
Cloned the repo to play around and found this rogue string in there... luckily CSS is very forgiving so it wasn't actually breaking the theme ✨

<img width="557" alt="image" src="https://github.com/tazpellegrini/abyssalobsidian/assets/3229933/e1fd646d-e28c-4b9a-8319-3cb468d72793">
